### PR TITLE
fix: git ignore package-lock.json

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,3 +23,5 @@ dist-ssr
 *.sln
 *.sw?
 .env
+
+package-lock.json


### PR DESCRIPTION
## 📄 Summary
- git ignore package-lock.json
<br/>

## ✏️ Describe your changes
- add `package-lock.json` at `.gitignore`
<br/>

## 📍 Issue number and link
-
<br>
